### PR TITLE
Show the description of a thing if there is no 'about' text.

### DIFF
--- a/js/resultBuilder.js
+++ b/js/resultBuilder.js
@@ -813,7 +813,7 @@
 				}
 			}
 		}
-		if (!$text)
+		if($text === null)
 			$text = description;
 
 		return $('<article>')

--- a/js/resultBuilder.js
+++ b/js/resultBuilder.js
@@ -814,8 +814,10 @@
 			}
 		}
 		if($text === null) {
-			$text = description;
-        }
+			$text = $('<div>')
+					.addClass('card-text')
+					.text(description)
+		}
 
 		return $('<article>')
 			.append($image)

--- a/js/resultBuilder.js
+++ b/js/resultBuilder.js
@@ -813,6 +813,8 @@
 				}
 			}
 		}
+		if (!$text)
+			$text = description;
 
 		return $('<article>')
 			.append($image)

--- a/js/resultBuilder.js
+++ b/js/resultBuilder.js
@@ -813,8 +813,9 @@
 				}
 			}
 		}
-		if($text === null)
+		if($text === null) {
 			$text = description;
+        }
 
 		return $('<article>')
 			.append($image)


### PR DESCRIPTION
When there is no text, it makes sense to show the description (besides in the name's title attribute).

This patch show the description if there is no about, but doing the opposite thing makes more sense, in my opinion.